### PR TITLE
Remove unnecessary delay in command throttling

### DIFF
--- a/src/NavigationCommandObserver.ts
+++ b/src/NavigationCommandObserver.ts
@@ -26,7 +26,7 @@ class NavigationCommandObserver {
 
     setTimeout(() => {
       this.removeCommand(id);
-    }, 150);
+    }, 0);
   };
 
   private removeCommand = (id: string) => {


### PR DESCRIPTION
We don't really need a delay here because all we want is to remove that command when the thread is not busy executing the command, delaying it to the next run loop is totally enough.
I added it to the example PR I did back then to have extra confidence but we should decrease it to zero as it delaying our render tests.
