### PR TITLE
Use lodash 4.17.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "release": "npm version patch && tsc && npm publish && git clean -f"
   },
   "dependencies": {
-    "lodash": "^4.17.20"
+    "lodash": "4.17.15"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -22,7 +22,6 @@
     "babel-jest": "^26.6.3",
     "eslint": "7.14.0",
     "jest": "^26.6.3",
-    "lodash": "4.17.15",
     "metro-react-native-babel-preset": "^0.66.0",
     "react-native-codegen": "^0.0.7",
     "react-test-renderer": "17.0.2",
@@ -43,7 +42,6 @@
     "typescript": "^4.1.2"
   },
   "peerDependencies": {
-    "lodash": "^4.17.15",
     "react-native-navigation": "7.x.x",
     "react": "*",
     "react-native": "*"


### PR DESCRIPTION
It's best to use the same `lodash` version as [engine](https://github.com/wix-private/wix-one-app-engine/blob/d7bdc1c6bca7a8146836a85c6a5a2b59e9ff3eec/src/wix-one-app-engine/package.json#L178). With different version app bundle is bigger, and Jest tests that use components from UI Lib run slower (because they have to parse 2 versions of `lodash`).

I'm proposing also moving dep to dev - that way when engine changes `lodash` version, this lib does not have to be immediately updated.