### PR TITLE
Removing @react-native-community/picker dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@react-native-community/datetimepicker": "^3.0.6",
     "@react-native-community/eslint-config": "^2.0.0",
     "@react-native-community/netinfo": "^5.9.7",
-    "@react-native-community/picker": "^1.8.1",
     "@types/jest": "^26.0.15",
     "@types/lodash": "^4.14.165",
     "@types/react": "^16.14.0",


### PR DESCRIPTION
Removing @react-native-community/picker dep as react-native-ui-lib v7 no longer use it