### PR TITLE
feat: add initial tab index to navigation state

### DIFF
--- a/src/NavigationState.ts
+++ b/src/NavigationState.ts
@@ -8,6 +8,7 @@ interface State {
   activeScreenId?: string;
   activeComponentName?: string;
   activeTabIndex: number;
+  initialTabIndex: number;
   isActiveScreenId: (screenId: string) => boolean;
 }
 
@@ -15,6 +16,7 @@ const state: State = {
   stackCounter: 0,
   activeScreenId: undefined,
   activeTabIndex: 0,
+  initialTabIndex: 0,
   isActiveScreenId: (screenId: string) => screenId === activeScreenId,
   activeComponentName: undefined,
 };
@@ -73,6 +75,12 @@ Navigation.events().registerComponentDidAppearListener((event: ComponentDidAppea
 Navigation.events().registerCommandListener((name, params) => {
   if (params.commandId && name === CommandName.ShowOverlay) {
     overlayWasShown = true;
+  }
+
+  if (name === CommandName.SetRoot) {
+    const initialTabIndex = params?.layout?.root?.data?.bottomTabs?.currentTabIndex ?? 0;
+    state.initialTabIndex = initialTabIndex;
+    state.activeTabIndex = initialTabIndex;
   }
 });
 

--- a/src/NavigationState.ts
+++ b/src/NavigationState.ts
@@ -78,7 +78,7 @@ Navigation.events().registerCommandListener((name, params) => {
   }
 
   if (name === CommandName.SetRoot) {
-    const initialTabIndex = params?.layout?.root?.data?.bottomTabs?.currentTabIndex ?? 0;
+    const initialTabIndex = params?.layout?.root?.data?.options?.bottomTabs?.currentTabIndex ?? 0;
     state.initialTabIndex = initialTabIndex;
     state.activeTabIndex = initialTabIndex;
   }

--- a/src/NavigationState.ts
+++ b/src/NavigationState.ts
@@ -8,7 +8,6 @@ interface State {
   activeScreenId?: string;
   activeComponentName?: string;
   activeTabIndex: number;
-  initialTabIndex: number;
   isActiveScreenId: (screenId: string) => boolean;
 }
 
@@ -16,7 +15,6 @@ const state: State = {
   stackCounter: 0,
   activeScreenId: undefined,
   activeTabIndex: 0,
-  initialTabIndex: 0,
   isActiveScreenId: (screenId: string) => screenId === activeScreenId,
   activeComponentName: undefined,
 };
@@ -79,7 +77,6 @@ Navigation.events().registerCommandListener((name, params) => {
 
   if (name === CommandName.SetRoot) {
     const initialTabIndex = params?.layout?.root?.data?.options?.bottomTabs?.currentTabIndex ?? 0;
-    state.initialTabIndex = initialTabIndex;
     state.activeTabIndex = initialTabIndex;
   }
 });


### PR DESCRIPTION
add `initialTabIndex` to `NavigationState`.
also set the initial `activeTabIndex` according to the `initialTabIndex`